### PR TITLE
build: fix tokenizers error and dependency conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "libarchive-c~=4.0",
   "scikit-learn~=1.1",
   "tokenizers==0.15",
-  "uniformers>=4.20.0",
+  "transformers>=4.20.0",
   # quickfix, official pypi package doesn't work yet for python > 3.7
   "ipapy @ https://github.com/ionite34/ipapy/archive/4fedf540a68b998ddd982c05f113d40aa4f3f97f.zip"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   "numpy~=1.22",
   "torch>=1.11",
   "zstandard~=0.17",
-  "transformers==4.20.0",
   "lxml~=4.9",
   "sacremoses~=0.0.53",
   "optuna~=2.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ keywords = [
 license = {text = "Apache-2.0 License"}
 dependencies = [
   "datasets~=2.3",
-  "numpy~=1.22",
   "torch>=1.11",
   "zstandard~=0.17",
   "lxml~=4.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
   "optuna~=2.10",
   "libarchive-c~=4.0",
   "scikit-learn~=1.1",
+  "tokenizers==0.15",
+  "uniformers>=4.20.0",
   # quickfix, official pypi package doesn't work yet for python > 3.7
   "ipapy @ https://github.com/ionite34/ipapy/archive/4fedf540a68b998ddd982c05f113d40aa4f3f97f.zip"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ license = {text = "Apache-2.0 License"}
 dependencies = [
   "datasets~=2.3",
   "numpy~=1.22",
-  "tokenizers~=0.12",
   "torch>=1.11",
   "zstandard~=0.17",
   "transformers==4.20.0",


### PR DESCRIPTION
uniformers depends on tokenizers~=0.12 but there are errors in this tokenizers version:

```
 warning: variable does not need to be mutable
         --> tokenizers-lib/src/models/unigram/model.rs:265:21
          |
      265 |                 let mut target_node = &mut best_path_ends_at[key_pos];
          |                     ----^^^^^^^^^^^
          |                     |
          |                     help: remove this `mut`
          |
          = note: #[warn(unused_mut)] on by default
      
      warning: variable does not need to be mutable
         --> tokenizers-lib/src/models/unigram/model.rs:282:21
          |
      282 |                 let mut target_node = &mut best_path_ends_at[starts_at + mblen];
          |                     ----^^^^^^^^^^^
          |                     |
          |                     help: remove this `mut`
      
      warning: variable does not need to be mutable
         --> tokenizers-lib/src/pre_tokenizers/byte_level.rs:200:59
          |
      200 |     encoding.process_tokens_with_offsets_mut(|(i, (token, mut offsets))| {
          |                                                           ----^^^^^^^
          |                                                           |
          |                                                           help: remove this `mut`
      
      error: casting `&T` to `&mut T` is undefined behavior, even if the reference is unused, consider instead using an `UnsafeCell`
         --> tokenizers-lib/src/models/bpe/trainer.rs:526:47
          |
      522 |                     let w = &words[*i] as *const _ as *mut _;
          |                             -------------------------------- casting happend here
      ...
      526 |                         let word: &mut Word = &mut (*w);
          |                                               ^^^^^^^^^
          |
          = note: for more information, visit <https://doc.rust-lang.org/book/ch15-05-interior-mutability.html>
          = note: `#[deny(invalid_reference_casting)]` on by default
      
      warning: `tokenizers` (lib) generated 3 warnings
      error: could not compile `tokenizers` (lib) due to previous error; 3 warnings emitted`
```

In the newest tokenizers version (0.15) these errors do not occur, but uniformers depends on transformers==4.20.0 which is not compatible with tokenizers==0.15.0 so that there are dependency conflicts.

I have fixed this by changing the dependencies for tokenizers and transformers in uniformers so that pip attempts to solve the dependency conflicts. Now uniformers can be built without errors.