### PR TITLE
Updated transformers and tokenizers versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ keywords = [
 license = {text = "Apache-2.0 License"}
 dependencies = [
   "datasets~=2.3",
-  "numpy~=1.22",
-  "tokenizers~=0.12",
+  "numpy~=1.26.3",
+  "tokenizers~=0.19.0",
   "torch>=1.11",
   "zstandard~=0.17",
-  "transformers==4.20.0",
+  "transformers==4.43.3",
   "lxml~=4.9",
   "sacremoses~=0.0.53",
   "optuna~=2.10",


### PR DESCRIPTION
I saw the other PR to update these versions, but it appears to have gone stale so I thought it might be best to create a fresh one. As requested in the other thread, I have left transformers pinned to a specific version, but I have updated it to 4.43.3. This version depends on tokenizers>=0.19,<0.20, so I have updated that as well (though it could probably be removed since transformers depends on it already). I have tested this set of dependencies with nllg/bygpt5-base-en and nllg/bygpt5-medium-en, and everything appears to be working on my end. 

Thanks!